### PR TITLE
feat: polish empty canvas and AI modal header

### DIFF
--- a/src/components/AiGenerateModal.tsx
+++ b/src/components/AiGenerateModal.tsx
@@ -547,11 +547,12 @@ export const AiGenerateModal = ({ open, onClose, controller, targetSlide, onPrep
         <div className="ai-modal-card" role="dialog" aria-modal="true" aria-label={isEditMode ? 'Edit screen with AI' : 'Generate with AI'}>
           <div className="ai-modal-header">
             <div className="ai-modal-title">
-              <AiGenerative size={16} />
-              <div>
-                <h2>{isEditMode ? 'Edit screen with AI' : 'Generate with AI'}</h2>
-                {targetSlide && <span>{targetSlide.name}</span>}
-              </div>
+              <h2>{isEditMode ? 'Edit screen with AI' : 'Generate with AI'}</h2>
+              <p>
+                {isEditMode
+                  ? (targetSlide ? targetSlide.name : 'Tell us what to change on this screen.')
+                  : 'Describe your app — we\'ll build the screens.'}
+              </p>
             </div>
             <button className="ai-modal-close" onClick={requestClose} aria-label="Close"><X size={16} /></button>
           </div>

--- a/src/components/EditorCanvas.test.tsx
+++ b/src/components/EditorCanvas.test.tsx
@@ -178,8 +178,11 @@ describe('EditorCanvas screen actions', () => {
     root.innerHTML = markup
 
     expect(root.querySelector('#editor-empty-state-title')?.textContent)
-      .toBe('Create your first screen')
+      .toBe('Your canvas is empty')
+    expect(root.querySelector('.editor-empty-state-phone')).not.toBeNull()
+    expect(root.querySelector('.editor-empty-state-phone-island')).not.toBeNull()
+    expect(root.querySelector('.editor-empty-state-artboard-plus')).toBeNull()
     expect(Array.from(root.querySelectorAll('button')).map((button) => button.textContent.trim()))
-      .toEqual(['Blank screen', 'Generate with AI'])
+      .toEqual(['Generate with AI', 'Blank screen'])
   })
 })

--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -194,24 +194,34 @@ export const EditorCanvas = ({
         ? (
             <section className="editor-empty-state" aria-labelledby="editor-empty-state-title">
               <div className="editor-empty-state-content">
-                <span className="editor-empty-state-icon" aria-hidden="true">
-                  <Plus size={20} />
-                </span>
-                <h1 id="editor-empty-state-title">Create your first screen</h1>
-                <p>Start with a blank canvas or let AI create a first draft for you.</p>
+                <div className="editor-empty-state-phone" aria-hidden="true">
+                  <div className="editor-empty-state-phone-frame">
+                    <div className="editor-empty-state-phone-screen">
+                      <span className="editor-empty-state-phone-island" />
+                      <div className="editor-empty-state-phone-skeleton">
+                        <span className="editor-empty-state-skel editor-empty-state-skel-title" />
+                        <span className="editor-empty-state-skel editor-empty-state-skel-hero" />
+                        <span className="editor-empty-state-skel editor-empty-state-skel-line" />
+                        <span className="editor-empty-state-skel editor-empty-state-skel-line is-short" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <h1 id="editor-empty-state-title">Your canvas is empty</h1>
+                <p>Add a blank screen, or generate a first draft with AI.</p>
                 <div className="editor-empty-state-actions">
-                  <Button className="editor-empty-state-primary" size="lg" onClick={onAddSlide}>
-                    <Plus size={16} />
-                    Blank screen
-                  </Button>
                   <Button
-                    variant="outline"
+                    className="editor-empty-state-primary"
                     size="lg"
                     onClick={onGenerateWithAi}
                     disabled={aiActionsDisabled}
                   >
                     <AiGenerative size={16} />
                     Generate with AI
+                  </Button>
+                  <Button variant="outline" size="lg" onClick={onAddSlide}>
+                    <Plus size={16} />
+                    Blank screen
                   </Button>
                 </div>
               </div>

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -429,8 +429,60 @@ button:disabled { cursor: not-allowed; opacity: .35; }
 .stage-noise { position: fixed; inset: 62px 0 0 386px; pointer-events: none; opacity: .18; z-index: 0; background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.09'/%3E%3C/svg%3E"); }
 .is-sidebar-collapsed .stage-noise { left: 52px; }
 .editor-empty-state { min-height: 100%; display: grid; place-items: center; padding: 48px; position: relative; z-index: 2; }
-.editor-empty-state-content { width: min(420px, 100%); display: flex; flex-direction: column; align-items: center; color: var(--foreground); text-align: center; }
-.editor-empty-state-icon { width: 46px; height: 46px; display: grid; place-items: center; margin-bottom: 18px; border: 1px solid var(--border); border-radius: var(--radius-lg); background: var(--background); box-shadow: 0 4px 14px oklch(0 0 0 / 7%); }
+.editor-empty-state-content { width: min(380px, 100%); display: flex; flex-direction: column; align-items: center; color: var(--foreground); text-align: center; }
+.editor-empty-state-phone {
+  width: min(188px, 48vw);
+  margin: 0 auto 22px;
+  filter: drop-shadow(0 14px 24px color-mix(in oklch, var(--foreground) 12%, transparent));
+}
+.editor-empty-state-phone-frame {
+  aspect-ratio: 9 / 17;
+  padding: 8px;
+  border-radius: 32px;
+  background: color-mix(in oklch, var(--foreground) 12%, var(--background));
+  box-shadow: 0 0 0 1px color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.editor-empty-state-phone-screen {
+  position: relative;
+  height: 100%;
+  border-radius: 24px;
+  overflow: hidden;
+  background: color-mix(in oklch, var(--background) 88%, var(--muted));
+}
+.editor-empty-state-phone-island {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  z-index: 1;
+  width: 36%;
+  height: 12px;
+  translate: -50% 0;
+  border-radius: 999px;
+  background: #111110;
+}
+.editor-empty-state-phone-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  padding: 40px 16px 20px;
+}
+.editor-empty-state-skel {
+  display: block;
+  flex: 0 0 auto;
+  border-radius: 8px;
+  background: color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+.editor-empty-state-skel-title { width: 48%; height: 9px; border-radius: 999px; }
+.editor-empty-state-skel-hero {
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  border-radius: 14px;
+  margin-top: 2px;
+}
+.editor-empty-state-skel-line { width: 100%; height: 7px; border-radius: 999px; }
+.editor-empty-state-skel-line.is-short { width: 58%; opacity: .7; }
 .editor-empty-state h1 { margin: 0; line-height: 1.05; }
 .editor-empty-state p { max-width: 360px; margin: 10px 0 0; color: var(--muted-foreground); font-size: var(--editor-text-md); line-height: 1.5; }
 .editor-empty-state-actions { display: flex; align-items: center; justify-content: center; gap: 8px; margin-top: 22px; }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -593,16 +593,56 @@ button:disabled { cursor: not-allowed; opacity: .35; }
 @keyframes ai-modal-fade { from { opacity: 0; } }
 .ai-modal-card { width: 100%; max-width: 560px; max-height: 86vh; background: var(--panel); border: 1px solid #dcdbd3; border-radius: 14px; box-shadow: 0 24px 60px rgba(20,20,16,.28), 0 0 0 1px rgba(0,0,0,.04); display: flex; flex-direction: column; overflow: hidden; animation: ai-modal-in .22s cubic-bezier(.2,.8,.3,1) both; }
 @keyframes ai-modal-in { from { opacity: 0; transform: translateY(10px) scale(.98); } }
-.ai-modal-header { display: flex; align-items: center; justify-content: space-between; padding: 18px 18px 14px; border-bottom: 1px solid var(--line); flex: 0 0 auto; }
-.ai-modal-title { display: flex; align-items: center; gap: 8px; color: var(--ink); }
-.ai-modal-title svg { color: var(--accent); }
-.ai-modal-title > div { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
-.ai-modal-title h2 { margin: 0; font-family: 'Bricolage Grotesque Variable'; font-size: 17px; letter-spacing: -.4px; }
-.ai-modal-title span { max-width: 420px; overflow: hidden; color: var(--muted); font-size: 9px; font-weight: 560; text-overflow: ellipsis; white-space: nowrap; }
-.ai-modal-close { width: 28px; height: 28px; border: 0; background: transparent; color: #8a8a81; border-radius: 6px; display: grid; place-items: center; cursor: pointer; }
-.ai-modal-close:hover { background: #ece9e1; color: #23231f; }
+.ai-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 14px 4px 20px;
+  flex: 0 0 auto;
+}
+.ai-modal-title {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--ink);
+}
+.ai-modal-title h2 {
+  margin: 0;
+  font-weight: 700;
+  line-height: 1.1;
+}
+.ai-modal-title p {
+  margin: 0;
+  max-width: 36ch;
+  color: var(--muted);
+  font-size: 12.5px;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ai-modal-close {
+  width: 32px;
+  height: 32px;
+  margin-top: -2px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #8a8a81;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  flex: 0 0 auto;
+}
+.ai-modal-close:hover {
+  background: #ece9e1;
+  color: #23231f;
+  border-color: rgba(23, 23, 19, 0.06);
+}
 
-.ai-modal-body { padding: 18px; overflow-y: auto; scrollbar-width: thin; scrollbar-color: #c9c9c1 transparent; }
+.ai-modal-body { padding: 14px 18px 18px; overflow-y: auto; scrollbar-width: thin; scrollbar-color: #c9c9c1 transparent; }
 .ai-modal-field { display: flex; flex-direction: column; gap: 7px; margin-bottom: 16px; }
 .ai-modal-field:last-child { margin-bottom: 0; }
 .ai-modal-field--grow { flex: 1 1 auto; min-width: 0; margin-bottom: 0; }
@@ -670,19 +710,21 @@ button:disabled { cursor: not-allowed; opacity: .35; }
   align-items: center;
   gap: 5px;
   margin: 0;
-  padding: 0;
-  border: 0;
+  padding: 3px 7px;
+  border: 1px dashed var(--muted-foreground);
+  border-radius: 6px;
   background: transparent;
   color: var(--muted-foreground);
   font-size: 10px;
   font-weight: 620;
   letter-spacing: .05px;
-  text-decoration: underline;
-  text-underline-offset: 2px;
   cursor: pointer;
   white-space: nowrap;
+  transition: transform .08s ease;
 }
-.ai-modal-copy-prompt:hover { color: var(--foreground); }
+.ai-modal-copy-prompt:active {
+  transform: translateY(1px) scale(.97);
+}
 .ai-modal-copy-prompt svg { flex: 0 0 auto; }
 
 .ai-model-picker-trigger {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -710,16 +710,15 @@ select:focus-visible {
   box-shadow: inset 0 0 0 1px var(--border);
 }
 
-.ai-modal-header,
 .ai-modal-footer { border-color: var(--border); }
 .ai-modal-title { color: var(--foreground); }
-.ai-modal-title svg { color: var(--foreground); }
-.ai-modal-title span { color: var(--muted-foreground); }
+.ai-modal-title p { color: var(--muted-foreground); }
 .ai-modal-close { color: var(--muted-foreground); }
 
 .ai-modal-close:hover {
   background: var(--accent);
   color: var(--accent-foreground);
+  border-color: color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
 .ai-modal-body { scrollbar-color: var(--border) transparent; }


### PR DESCRIPTION
## Summary
- Redesign the empty editor canvas with a phone skeleton preview and AI-first CTA ordering
- Simplify the AI generate modal header to a clearer title-and-subtitle layout
- Update empty-state coverage and matching theme/base styles for both surfaces

## Test plan
- [ ] Open the editor with no screens and confirm empty state copy, phone preview, and button order (`Generate with AI` then `Blank screen`)
- [ ] Click both empty-state actions and confirm they still open blank screen / AI generate correctly
- [ ] Open Generate with AI and Edit with AI; confirm header title/subtitle and close control look correct in light theme
- [ ] Run `bun run check` (or at least `bun run test` for `EditorCanvas`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a phone-style preview and refreshed messaging for empty canvases.
  * AI generation is now the primary empty-canvas action, with blank-screen creation as a secondary option.
  * AI generation and editing modals now include clearer contextual descriptions.

* **Style**
  * Refined modal layout, spacing, close-button states, and copy-prompt styling.
  * Updated empty-state visuals with a polished phone mockup preview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->