### PR TITLE
ci: deploy editor to Cloudflare after main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validate:
@@ -33,3 +33,28 @@ jobs:
 
       - name: Run checks
         run: bun run check
+
+  deploy:
+    name: Deploy
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Deploy
+        run: bun run deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -12,6 +12,12 @@ bun run check
 bun run deploy
 ```
 
+Pushes and merges to `main` also deploy automatically after CI quality gates
+pass (`.github/workflows/ci.yml`). Configure these repository secrets:
+
+- `CLOUDFLARE_API_TOKEN` — API token with Edit Cloudflare Workers permission
+- `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account ID
+
 The Cloudflare custom domain is source-controlled in `wrangler.jsonc`. Do not
 attach this Worker to the apex domain, and do not add marketing-site source,
 styles, assets, or production-only configuration to this repository.


### PR DESCRIPTION
## Summary
- Add a `deploy` job to CI that runs `bun run deploy` after quality gates on pushes/merges to `main`
- Keep PR runs check-only; avoid cancelling in-progress main deploys when new commits land
- Document required `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repository secrets

## Test plan
- [ ] Confirm repository secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are set
- [ ] Open this PR and verify only the `validate` job runs (no deploy)
- [ ] Merge to `main` and verify CI runs validate → deploy successfully
- [ ] Confirm `https://app.shotluma.com` reflects the merged build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now run automatically after successful validation when changes are pushed or merged to `main`.
  * Added deployment using configured Cloudflare credentials.

* **Documentation**
  * Documented the automatic deployment process and required repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->