### PR TITLE
ci: isolate Cloudflare credentials from build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -53,8 +55,11 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build
+        run: bun run build
+
       - name: Deploy
-        run: bun run deploy
+        run: bun run deploy-only
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -9,7 +9,8 @@ maintained and deployed from a separate private repository.
 ```bash
 bun install --frozen-lockfile
 bun run check
-bun run deploy
+bun run build
+bun run deploy-only
 ```
 
 Pushes and merges to `main` also deploy automatically after CI quality gates
@@ -21,3 +22,8 @@ pass (`.github/workflows/ci.yml`). Configure these repository secrets:
 The Cloudflare custom domain is source-controlled in `wrangler.jsonc`. Do not
 attach this Worker to the apex domain, and do not add marketing-site source,
 styles, assets, or production-only configuration to this repository.
+
+Keep `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` available only to the
+`bun run deploy-only` command. The GitHub Actions workflow follows the same
+boundary: it builds without Cloudflare credentials and supplies them only to
+the deployment step.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typecheck": "tsc -b",
     "build": "bun run typecheck && vite build",
     "deploy": "bun run build && wrangler deploy",
+    "deploy-only": "wrangler deploy",
     "preview": "vite preview",
     "structure": "bun scripts/check-structure.ts",
     "lint": "eslint . --max-warnings 0",


### PR DESCRIPTION
## What this changes

- build `dist` without Cloudflare credentials
- run `wrangler deploy` in a separate credentialed step
- add `deploy-only` for the deployment command
- disable checkout token persistence in the deploy job
- document the credential boundary

## Why

This is a stacked follow-up to #13. The workflow still deploys on every push to `main`, including merges, because the existing `push` trigger is unchanged.

## Verification

- `bun run check`

Closes the CodeRabbit follow-up comments for #13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment workflows now build the application before publishing it.
  * Builds can run without deployment credentials, which are supplied only when publishing.
  * Added a deployment-only option for environments where the build has already completed.

* **Documentation**
  * Updated deployment instructions to reflect the separate build and publish steps.
  * Clarified credential requirements for local and automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->