### PR TITLE
feat(persistence): store images as disk-backed blobs and load workspaces lazily

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,6 +62,7 @@
         "eslint-plugin-import-x": "^4.17.1",
         "eslint-plugin-react-hooks": "latest",
         "eslint-plugin-react-refresh": "latest",
+        "fake-indexeddb": "^6.2.5",
         "globals": "latest",
         "jsdom": "^29.1.1",
         "typescript": "5.9.3",
@@ -827,6 +828,8 @@
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "express-rate-limit": ["express-rate-limit@8.6.0", "", { "dependencies": { "debug": "^4.4.3", "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -70,7 +70,15 @@ Values over roughly `52` are usually incorrect.
 
 ## Persistence
 
-`src/persistence.ts` stores project data and uploaded assets in IndexedDB. A small local-storage migration path exists for legacy projects.
+`src/persistence.ts` stores project documents in IndexedDB (database opening and store names live in `src/persistence-db.ts`). A small local-storage migration path exists for legacy projects.
+
+Image bytes are kept out of project documents and out of the JS heap:
+
+- `src/asset-store.ts` stores every image as a Blob in a content-addressed `assets` store (SHA-256 id), which Chrome keeps disk-backed. Identical images deduplicate across projects automatically.
+- Persisted documents reference images as `blob-asset:<id>`; the running app renders object URLs. `src/asset-sources.ts` owns the pure walk over the fields that can carry an image source (uploads, background images, image elements, device screenshots).
+- Loading a project resolves references to object URLs; documents saved before the asset store existed carry inline data URLs, which are converted to stored Blobs on load and persisted as references on the next save.
+- Starting the app reads project summaries with a cursor, so only the active project document is fully retained in memory.
+- Deleting a project sweeps stored Blobs that no surviving project references.
 
 Persistence is browser-local:
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -78,7 +78,8 @@ Image bytes are kept out of project documents and out of the JS heap:
 - Persisted documents reference images as `blob-asset:<id>`; the running app renders object URLs. `src/asset-sources.ts` owns the pure walk over the fields that can carry an image source (uploads, background images, image elements, device screenshots).
 - Loading a project resolves references to object URLs; documents saved before the asset store existed carry inline data URLs, which are converted to stored Blobs on load and persisted as references on the next save.
 - Starting the app reads project summaries with a cursor, so only the active project document is fully retained in memory.
-- Deleting a project sweeps stored Blobs that no surviving project references.
+- Deleting a project sweeps stored Blobs that no surviving project references. The sweep deliberately keeps every asset seen in the current session: unsaved in-memory state and undo history can reference assets no persisted document mentions, so those Blobs stay until a later session's sweep. Object URLs are never revoked for the same reason — they pin disk-backed Blobs, not heap memory.
+- Sweeping scans and deletes in separate transactions. Concurrent editing from a second tab is not a supported model (the database open already rejects when another tab blocks an upgrade); a save racing a delete across tabs could at worst strand one `blob-asset:` reference, which renders as a missing image.
 
 Persistence is browser-local:
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "eslint-plugin-import-x": "^4.17.1",
     "eslint-plugin-react-hooks": "latest",
     "eslint-plugin-react-refresh": "latest",
+    "fake-indexeddb": "^6.2.5",
     "globals": "latest",
     "jsdom": "^29.1.1",
     "typescript": "5.9.3",

--- a/src/ai/overlay-asset-tools.ts
+++ b/src/ai/overlay-asset-tools.ts
@@ -1,5 +1,6 @@
 import { generateImage, tool } from 'ai'
 import { z } from 'zod'
+import { fileToDataUrl } from '../utils'
 import { ASSET_CHROMA_KEY_HEX } from './chroma-key'
 import {
   OVERLAY_ASSET_BUDGET,
@@ -25,6 +26,14 @@ const dataUrlToBase64 = (dataUrl: string): string => {
   const comma = dataUrl.indexOf(',')
   if (comma === -1) return dataUrl
   return dataUrl.slice(comma + 1)
+}
+
+// Upload sources are object URLs backed by stored Blobs (data URLs only as a
+// storage fallback), so provider payloads fetch the bytes back before encoding.
+const sourceToBase64 = async (src: string): Promise<string> => {
+  if (src.startsWith('data:')) return dataUrlToBase64(src)
+  const blob = await (await fetch(src)).blob()
+  return dataUrlToBase64(await fileToDataUrl(blob))
 }
 
 const sanitizeAssetName = (name: string): string => {
@@ -69,15 +78,19 @@ const toAssetModelOutput = (output: OverlayAssetToolResult) => {
   }
 }
 
-const resolveReferenceImages = (
+const resolveReferenceImages = async (
   controller: ToolContext['controller'],
   referenceAssetIds: string[] | undefined,
-): { ok: true; images: string[] } | { ok: false; error: string } => {
+): Promise<{ ok: true; images: string[] } | { ok: false; error: string }> => {
   const images: string[] = []
   for (const assetId of referenceAssetIds ?? []) {
     const src = controller.getAssetSrc(assetId)
     if (!src) return notFound(assetNotFoundMessage(assetId))
-    images.push(dataUrlToBase64(src))
+    try {
+      images.push(await sourceToBase64(src))
+    } catch {
+      return notFound(assetNotFoundMessage(assetId))
+    }
   }
   return { ok: true, images }
 }
@@ -188,7 +201,7 @@ PROMPTING: describe ONLY the subject — one object, its material, style, colors
         }
       }
 
-      const references = resolveReferenceImages(controller, referenceAssetIds)
+      const references = await resolveReferenceImages(controller, referenceAssetIds)
       if (!references.ok) return references
 
       emit({ tool: 'create_overlay_asset' })

--- a/src/ai/use-ai-workflow.ts
+++ b/src/ai/use-ai-workflow.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type Dispatch, type RefObject, type SetStateAction } from 'react'
+import { importDataUrlAsset } from '../asset-store'
 import { uid } from '../utils'
 import { createAiController } from './controller'
 import type { Slide, UploadAsset } from '../types'
@@ -127,21 +128,26 @@ export function useAiWorkflow({
     return () => window.clearTimeout(timer)
   }, [activity])
 
-  const prepareRun = useCallback((files: { name: string; dataUrl: string }[]) => {
+  const prepareRun = useCallback(async (files: { name: string; dataUrl: string }[]) => {
     checkpoint()
     clearSelection()
     preRunSlideIds.current = new Set(slidesRef.current.map((slide) => slide.id))
     const bySource = new Map(uploadsRef.current.map((asset) => [asset.src, asset]))
     const additions: UploadAsset[] = []
-    const prepared = files.map((file) => {
-      let asset = bySource.get(file.dataUrl)
+    const prepared: { assetId: string; name: string; dataUrl: string }[] = []
+    for (const file of files) {
+      // Uploads render from the stored Blob's object URL; the provider payload
+      // keeps the original data URL because AI requests need base64 content.
+      // Content-hashed storage makes re-attaching the same image dedupe here.
+      const src = await importDataUrlAsset(file.dataUrl)
+      let asset = bySource.get(src)
       if (!asset) {
-        asset = { id: uid('upload'), name: file.name, src: file.dataUrl }
+        asset = { id: uid('upload'), name: file.name, src }
         additions.push(asset)
         bySource.set(asset.src, asset)
       }
-      return { assetId: asset.id, name: asset.name, dataUrl: asset.src }
-    })
+      prepared.push({ assetId: asset.id, name: asset.name, dataUrl: file.dataUrl })
+    }
     if (additions.length > 0) {
       uploadsRef.current = [...additions, ...uploadsRef.current]
       setUploads(uploadsRef.current)

--- a/src/asset-sources.test.ts
+++ b/src/asset-sources.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { collectAssetSources, mapAssetSources } from './asset-sources'
+import type { Slide, UploadAsset } from './types'
+
+const makeSlide = (overrides: Partial<Slide> = {}): Slide => ({
+  id: 'slide-1',
+  name: 'Screen 1',
+  background: { type: 'solid', color1: '#000', color2: '#000', angle: 0 },
+  elements: [],
+  ...overrides,
+})
+
+const makeUpload = (src: string): UploadAsset => ({ id: 'upload-1', name: 'shot.png', src })
+
+const projectFixture = () => ({
+  uploads: [makeUpload('data:image/png;base64,AAA')],
+  slides: [
+    makeSlide({
+      background: { type: 'image', color1: '#000', color2: '#000', angle: 0, image: 'data:image/png;base64,BBB' },
+      elements: [
+        {
+          id: 'image-1', type: 'image' as const, x: 0, y: 0, width: 10, rotation: 0, opacity: 1,
+          src: 'data:image/png;base64,AAA', borderRadius: 0,
+        },
+        {
+          id: 'device-1', type: 'device' as const, x: 0, y: 0, width: 10, rotation: 0, opacity: 1,
+          deviceStyle: 'iphone-17-a' as const, screenTheme: 'coral' as const, tiltX: 0, tiltY: 0, shadow: 0,
+          screenshot: 'data:image/png;base64,CCC',
+        },
+        {
+          id: 'shape-1', type: 'shape' as const, x: 0, y: 0, width: 10, rotation: 0, opacity: 1,
+          shape: 'circle' as const, color: '#fff', strokeColor: '#000', strokeWidth: 0, shadow: 0,
+        },
+      ],
+    }),
+  ],
+})
+
+describe('collectAssetSources', () => {
+  it('collects uploads, background images, image elements, and device screenshots once each', () => {
+    expect(collectAssetSources(projectFixture())).toEqual(new Set([
+      'data:image/png;base64,AAA',
+      'data:image/png;base64,BBB',
+      'data:image/png;base64,CCC',
+    ]))
+  })
+
+  it('skips absent optional sources and empty projects', () => {
+    expect(collectAssetSources({ uploads: [], slides: [makeSlide()] })).toEqual(new Set())
+    expect(collectAssetSources({ uploads: [], slides: [] })).toEqual(new Set())
+  })
+})
+
+describe('mapAssetSources', () => {
+  it('rewrites every source field through the mapper', () => {
+    const mapped = mapAssetSources(projectFixture(), (src) => `mapped:${src.slice(-3)}`)
+    expect(mapped.uploads[0]?.src).toBe('mapped:AAA')
+    expect(mapped.slides[0]?.background.image).toBe('mapped:BBB')
+    expect(mapped.slides[0]?.elements[0]).toMatchObject({ src: 'mapped:AAA' })
+    expect(mapped.slides[0]?.elements[1]).toMatchObject({ screenshot: 'mapped:CCC' })
+  })
+
+  it('preserves untouched objects by identity so undo history keeps sharing structure', () => {
+    const project = projectFixture()
+    const identical = mapAssetSources(project, (src) => src)
+    expect(identical.slides[0]).toBe(project.slides[0])
+    expect(identical.uploads[0]).toBe(project.uploads[0])
+
+    const partial = mapAssetSources(project, (src) => src.endsWith('AAA') ? 'mapped:AAA' : src)
+    expect(partial.slides[0]).not.toBe(project.slides[0])
+    expect(partial.slides[0]?.background).toBe(project.slides[0]?.background)
+    expect(partial.slides[0]?.elements[1]).toBe(project.slides[0]?.elements[1])
+    expect(partial.slides[0]?.elements[2]).toBe(project.slides[0]?.elements[2])
+  })
+})

--- a/src/asset-sources.ts
+++ b/src/asset-sources.ts
@@ -1,0 +1,65 @@
+import type { CanvasElement, Slide, UploadAsset } from './types'
+
+/**
+ * Every place project data embeds an image source: upload assets, slide
+ * background images, image elements, and device screenshots. AI-authored
+ * `slide.html` is excluded on purpose — it references uploads through
+ * `asset:` upload ids and may only embed small self-authored SVG data URIs.
+ */
+export type ProjectAssetSources = {
+  slides: Slide[]
+  uploads: UploadAsset[]
+}
+
+export const collectAssetSources = ({ slides, uploads }: ProjectAssetSources): Set<string> => {
+  const sources = new Set<string>()
+  for (const upload of uploads) sources.add(upload.src)
+  for (const slide of slides) {
+    if (slide.background.image) sources.add(slide.background.image)
+    for (const element of slide.elements) {
+      if (element.type === 'image') sources.add(element.src)
+      else if (element.type === 'device' && element.screenshot) sources.add(element.screenshot)
+    }
+  }
+  return sources
+}
+
+const mapElementSources = (element: CanvasElement, map: (src: string) => string): CanvasElement => {
+  if (element.type === 'image') {
+    const src = map(element.src)
+    return src === element.src ? element : { ...element, src }
+  }
+  if (element.type === 'device' && element.screenshot) {
+    const screenshot = map(element.screenshot)
+    return screenshot === element.screenshot ? element : { ...element, screenshot }
+  }
+  return element
+}
+
+const mapBackgroundSources = (background: Slide['background'], map: (src: string) => string): Slide['background'] => {
+  if (background.image === undefined) return background
+  const image = map(background.image)
+  return image === background.image ? background : { ...background, image }
+}
+
+const mapSlideSources = (slide: Slide, map: (src: string) => string): Slide => {
+  const background = mapBackgroundSources(slide.background, map)
+  const elements = slide.elements.map((element) => mapElementSources(element, map))
+  const elementsChanged = elements.some((element, index) => element !== slide.elements[index])
+  if (background === slide.background && !elementsChanged) return slide
+  return {
+    ...slide,
+    background,
+    elements: elementsChanged ? elements : slide.elements,
+  }
+}
+
+/** Returns a structurally shared copy with every image source passed through `map`. */
+export const mapAssetSources = <T extends ProjectAssetSources>(project: T, map: (src: string) => string): T => {
+  const uploads = project.uploads.map((upload) => {
+    const src = map(upload.src)
+    return src === upload.src ? upload : { ...upload, src }
+  })
+  const slides = project.slides.map((slide) => mapSlideSources(slide, map))
+  return { ...project, uploads, slides }
+}

--- a/src/asset-store.test.ts
+++ b/src/asset-store.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment node
+import 'fake-indexeddb/auto'
+import { describe, expect, it } from 'vitest'
+import { ASSET_REF_PREFIX } from './asset-store'
+import {
+  deleteProject,
+  loadProject,
+  loadProjectWorkspace,
+  saveProject,
+  setActiveProjectId,
+  type PersistedProject,
+} from './persistence'
+import { ASSET_STORE, PROJECT_STORE, openDatabase } from './persistence-db'
+import type { Slide } from './types'
+
+const dataUrl = (payload: string) => `data:image/png;base64,${btoa(payload)}`
+
+const makeSlide = (id: string, overrides: Partial<Slide> = {}): Slide => ({
+  id,
+  name: id,
+  background: { type: 'solid', color1: '#000', color2: '#000', angle: 0 },
+  elements: [],
+  ...overrides,
+})
+
+const makeProject = (id: string, src: string, savedAt: number): PersistedProject => ({
+  id,
+  projectName: `Project ${id}`,
+  slides: [
+    makeSlide(`${id}-slide`, {
+      background: { type: 'image', color1: '#000', color2: '#000', angle: 0, image: src },
+      elements: [{
+        id: `${id}-image`, type: 'image', x: 0, y: 0, width: 10, rotation: 0, opacity: 1,
+        src, borderRadius: 0,
+      }],
+    }),
+  ],
+  uploads: [{ id: `${id}-upload`, name: 'shot.png', src }],
+  createdAt: savedAt,
+  savedAt,
+})
+
+const readRawRecord = async <T>(storeName: string, key: string): Promise<T | undefined> => {
+  const database = await openDatabase()
+  return new Promise((resolve, reject) => {
+    const request = database.transaction(storeName, 'readonly').objectStore(storeName).get(key)
+    request.onsuccess = () => resolve(request.result as T | undefined)
+    request.onerror = () => reject(request.error ?? new Error('read failed'))
+  })
+}
+
+const writeRawRecord = async (storeName: string, record: unknown): Promise<void> => {
+  const database = await openDatabase()
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(storeName, 'readwrite')
+    transaction.objectStore(storeName).put(record)
+    transaction.oncomplete = () => resolve()
+    transaction.onerror = () => reject(transaction.error ?? new Error('write failed'))
+  })
+}
+
+describe('blob asset persistence', () => {
+  it('persists image sources as blob-asset references and rehydrates one object URL per asset', async () => {
+    const source = dataUrl('roundtrip-image')
+    await saveProject(makeProject('roundtrip', source, 100))
+
+    const raw = await readRawRecord<PersistedProject>(PROJECT_STORE, 'roundtrip')
+    const ref = raw?.uploads[0]?.src
+    expect(ref).toMatch(new RegExp(`^${ASSET_REF_PREFIX}[0-9a-f]{64}$`))
+    expect(raw?.slides[0]?.background.image).toBe(ref)
+    expect(raw?.slides[0]?.elements[0]).toMatchObject({ src: ref })
+    expect(JSON.stringify(raw)).not.toContain('base64')
+
+    const assetId = (ref ?? '').slice(ASSET_REF_PREFIX.length)
+    const asset = await readRawRecord<{ id: string; blob: Blob }>(ASSET_STORE, assetId)
+    expect(asset?.blob).toBeInstanceOf(Blob)
+
+    const loaded = await loadProject('roundtrip')
+    const url = loaded?.uploads[0]?.src
+    expect(url).toMatch(/^blob:/)
+    expect(loaded?.slides[0]?.background.image).toBe(url)
+    expect(loaded?.slides[0]?.elements[0]).toMatchObject({ src: url })
+  })
+
+  it('migrates legacy inline data URLs to references on the first save after loading', async () => {
+    const legacySource = dataUrl('legacy-inline-image')
+    await writeRawRecord(PROJECT_STORE, makeProject('legacy', legacySource, 200))
+
+    const loaded = await loadProject('legacy')
+    expect(loaded?.uploads[0]?.src).toMatch(/^blob:/)
+    if (!loaded) throw new Error('legacy project failed to load')
+
+    await saveProject(loaded)
+    const raw = await readRawRecord<PersistedProject>(PROJECT_STORE, 'legacy')
+    expect(raw?.uploads[0]?.src).toMatch(new RegExp(`^${ASSET_REF_PREFIX}`))
+    expect(JSON.stringify(raw)).not.toContain('base64')
+  })
+
+  it('loads the workspace as summaries plus the hydrated configured project', async () => {
+    await saveProject(makeProject('workspace-old', dataUrl('workspace-old-image'), 300))
+    await saveProject(makeProject('workspace-new', dataUrl('workspace-new-image'), 400))
+    await setActiveProjectId('workspace-old')
+
+    const workspace = await loadProjectWorkspace()
+    expect(workspace.activeProject?.id).toBe('workspace-old')
+    expect(workspace.activeProject?.uploads[0]?.src).toMatch(/^blob:/)
+    const ids = workspace.projects.map((project) => project.id)
+    expect(ids.indexOf('workspace-new')).toBeLessThan(ids.indexOf('workspace-old'))
+    expect(workspace.projects.every((project) => !('slides' in project))).toBe(true)
+  })
+
+  it('falls back to the most recently saved project when the configured id is stale', async () => {
+    await setActiveProjectId('does-not-exist')
+    const workspace = await loadProjectWorkspace()
+    expect(workspace.activeProject?.id).toBe(workspace.projects[0]?.id)
+  })
+
+  it('sweeps blobs only the deleted project referenced and keeps shared ones', async () => {
+    const orphanId = 'f'.repeat(64)
+    const sharedId = 'e'.repeat(64)
+    await writeRawRecord(ASSET_STORE, { id: orphanId, blob: new Blob(['orphan']) })
+    await writeRawRecord(ASSET_STORE, { id: sharedId, blob: new Blob(['shared']) })
+    await writeRawRecord(PROJECT_STORE, makeProject('doomed', `${ASSET_REF_PREFIX}${orphanId}`, 500))
+    await writeRawRecord(PROJECT_STORE, makeProject('survivor', `${ASSET_REF_PREFIX}${sharedId}`, 600))
+
+    await deleteProject('doomed')
+
+    expect(await readRawRecord(PROJECT_STORE, 'doomed')).toBeUndefined()
+    expect(await readRawRecord(ASSET_STORE, orphanId)).toBeUndefined()
+    expect(await readRawRecord(ASSET_STORE, sharedId)).toBeDefined()
+  })
+})

--- a/src/asset-store.ts
+++ b/src/asset-store.ts
@@ -1,0 +1,198 @@
+import { collectAssetSources, mapAssetSources, type ProjectAssetSources } from './asset-sources'
+import { ASSET_STORE, openDatabase } from './persistence-db'
+import { fileToDataUrl } from './utils'
+
+/**
+ * Content-addressed image storage. Image bytes live as Blobs in the `assets`
+ * IndexedDB store, which Chrome keeps disk-backed; project documents persist
+ * only `blob-asset:<sha-256>` references, and the running app renders object
+ * URLs, so image data never sits in the JS heap as a base64 string. Hash ids
+ * make writes idempotent and deduplicate identical images across projects.
+ */
+
+export const ASSET_REF_PREFIX = 'blob-asset:'
+
+type AssetRecord = { id: string; blob: Blob }
+
+export const isAssetRef = (src: string) => src.startsWith(ASSET_REF_PREFIX)
+
+const assetIdFromRef = (src: string) => src.slice(ASSET_REF_PREFIX.length)
+
+// One object URL per asset per session. URLs are deliberately never revoked on
+// project switches: they only pin disk-backed Blobs, and reusing the same URL
+// string keeps src equality checks (background pickers, upload dedupe) working.
+const objectUrlByAssetId = new Map<string, string>()
+const assetIdByObjectUrl = new Map<string, string>()
+const assetIdByDataUrl = new Map<string, string>()
+
+const toObjectUrl = (id: string, blob: Blob): string => {
+  const cached = objectUrlByAssetId.get(id)
+  if (cached) return cached
+  const url = URL.createObjectURL(blob)
+  objectUrlByAssetId.set(id, url)
+  assetIdByObjectUrl.set(url, id)
+  return url
+}
+
+const hashBlob = async (blob: Blob): Promise<string> => {
+  const digest = await crypto.subtle.digest('SHA-256', await blob.arrayBuffer())
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export const dataUrlToBlob = (dataUrl: string): Blob => {
+  const comma = dataUrl.indexOf(',')
+  if (comma === -1) throw new Error('Malformed data URL.')
+  const header = dataUrl.slice(0, comma)
+  const type = /^data:([^;,]+)/.exec(header)?.[1] ?? 'application/octet-stream'
+  const payload = dataUrl.slice(comma + 1)
+  if (!header.includes(';base64')) return new Blob([decodeURIComponent(payload)], { type })
+  const binary = atob(payload)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index)
+  return new Blob([bytes], { type })
+}
+
+const putAssetRecord = async (record: AssetRecord): Promise<void> => {
+  const database = await openDatabase()
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(ASSET_STORE, 'readwrite')
+    transaction.objectStore(ASSET_STORE).put(record)
+    transaction.oncomplete = () => resolve()
+    transaction.onerror = () => reject(transaction.error ?? new Error('The image could not be stored locally.'))
+    transaction.onabort = () => reject(transaction.error ?? new Error('Storing the image was cancelled.'))
+  })
+}
+
+const storeBlobAsset = async (blob: Blob): Promise<{ id: string; url: string }> => {
+  const id = await hashBlob(blob)
+  if (!objectUrlByAssetId.has(id)) await putAssetRecord({ id, blob })
+  return { id, url: toObjectUrl(id, blob) }
+}
+
+/**
+ * Stores an uploaded image and returns the src to render it with. Falls back
+ * to an inline data URL when Blob storage is unavailable (e.g. private
+ * browsing), which keeps uploads working exactly as before the asset store.
+ */
+export const importBlobAsset = async (blob: Blob): Promise<string> => {
+  try {
+    return (await storeBlobAsset(blob)).url
+  } catch {
+    return fileToDataUrl(blob)
+  }
+}
+
+/** Same fallback contract as {@link importBlobAsset}, for data URL inputs. */
+export const importDataUrlAsset = async (dataUrl: string): Promise<string> => {
+  try {
+    const { id, url } = await storeBlobAsset(dataUrlToBlob(dataUrl))
+    assetIdByDataUrl.set(dataUrl, id)
+    return url
+  } catch {
+    return dataUrl
+  }
+}
+
+const loadAssetObjectUrls = async (ids: string[]): Promise<Map<string, string>> => {
+  const resolved = new Map<string, string>()
+  const missing = ids.filter((id) => {
+    const cached = objectUrlByAssetId.get(id)
+    if (cached) resolved.set(id, cached)
+    return !cached
+  })
+  if (missing.length === 0) return resolved
+
+  const database = await openDatabase()
+  const records = await new Promise<(AssetRecord | undefined)[]>((resolve, reject) => {
+    const transaction = database.transaction(ASSET_STORE, 'readonly')
+    const store = transaction.objectStore(ASSET_STORE)
+    const requests = missing.map((id) => store.get(id))
+    transaction.oncomplete = () => resolve(requests.map((request) => request.result as AssetRecord | undefined))
+    transaction.onerror = () => reject(transaction.error ?? new Error('Local images could not be loaded.'))
+    transaction.onabort = () => reject(transaction.error ?? new Error('Loading local images was cancelled.'))
+  })
+  for (const record of records) {
+    if (record) resolved.set(record.id, toObjectUrl(record.id, record.blob))
+  }
+  return resolved
+}
+
+/**
+ * Resolves a freshly loaded project for rendering: `blob-asset:` references
+ * become object URLs, and legacy inline data URLs (projects saved before the
+ * asset store existed) are converted into stored Blobs on the spot so the next
+ * save persists references instead of megabytes of base64.
+ */
+export const hydrateProjectAssets = async <T extends ProjectAssetSources>(project: T): Promise<T> => {
+  const sources = collectAssetSources(project)
+  const referencedIds = [...sources].filter(isAssetRef).map(assetIdFromRef)
+  const urlsById = await loadAssetObjectUrls(referencedIds).catch(() => new Map<string, string>())
+
+  const replacements = new Map<string, string>()
+  for (const src of sources) {
+    if (isAssetRef(src)) {
+      const url = urlsById.get(assetIdFromRef(src))
+      if (url) replacements.set(src, url)
+    } else if (src.startsWith('data:')) {
+      replacements.set(src, await importDataUrlAsset(src))
+    }
+  }
+  return mapAssetSources(project, (src) => replacements.get(src) ?? src)
+}
+
+/**
+ * Prepares a project snapshot for persistence: object URLs and any remaining
+ * inline data URLs become `blob-asset:` references. Sources that cannot be
+ * stored (or are regular bundled/HTTP URLs) are kept as-is, so a failed Blob
+ * write degrades to today's inline persistence instead of losing the image.
+ */
+export const dehydrateProjectAssets = async <T extends ProjectAssetSources>(project: T): Promise<T> => {
+  const replacements = new Map<string, string>()
+  for (const src of collectAssetSources(project)) {
+    const registeredId = assetIdByObjectUrl.get(src) ?? assetIdByDataUrl.get(src)
+    if (registeredId) {
+      replacements.set(src, `${ASSET_REF_PREFIX}${registeredId}`)
+    } else if (src.startsWith('data:')) {
+      try {
+        const { id } = await storeBlobAsset(dataUrlToBlob(src))
+        assetIdByDataUrl.set(src, id)
+        replacements.set(src, `${ASSET_REF_PREFIX}${id}`)
+      } catch {
+        // Keep the data URL inline; the project still round-trips.
+      }
+    }
+  }
+  return mapAssetSources(project, (src) => replacements.get(src) ?? src)
+}
+
+/** Asset ids referenced by a persisted (dehydrated) project document. */
+export const collectPersistedAssetIds = (project: ProjectAssetSources): Set<string> =>
+  new Set([...collectAssetSources(project)].filter(isAssetRef).map(assetIdFromRef))
+
+/**
+ * Deletes stored Blobs that no surviving project references. `keepIds` must
+ * include the ids referenced by every remaining persisted project; everything
+ * registered this session is also kept, because unsaved in-memory state (and
+ * legacy documents migrated on load but not yet saved) can reference assets
+ * that no document mentions yet.
+ */
+export const sweepUnusedAssets = async (keepIds: Set<string>): Promise<void> => {
+  const database = await openDatabase()
+  const storedIds = await new Promise<string[]>((resolve, reject) => {
+    const transaction = database.transaction(ASSET_STORE, 'readonly')
+    const request = transaction.objectStore(ASSET_STORE).getAllKeys()
+    request.onsuccess = () => resolve(request.result.map(String))
+    request.onerror = () => reject(request.error ?? new Error('Local images could not be listed.'))
+  })
+  const unused = storedIds.filter((id) => !keepIds.has(id) && !objectUrlByAssetId.has(id))
+  if (unused.length === 0) return
+
+  return new Promise((resolve, reject) => {
+    const transaction = database.transaction(ASSET_STORE, 'readwrite')
+    const store = transaction.objectStore(ASSET_STORE)
+    for (const id of unused) store.delete(id)
+    transaction.oncomplete = () => resolve()
+    transaction.onerror = () => reject(transaction.error ?? new Error('Unused local images could not be removed.'))
+    transaction.onabort = () => reject(transaction.error ?? new Error('Removing unused local images was cancelled.'))
+  })
+}

--- a/src/asset-store.ts
+++ b/src/asset-store.ts
@@ -19,11 +19,15 @@ export const isAssetRef = (src: string) => src.startsWith(ASSET_REF_PREFIX)
 const assetIdFromRef = (src: string) => src.slice(ASSET_REF_PREFIX.length)
 
 // One object URL per asset per session. URLs are deliberately never revoked on
-// project switches: they only pin disk-backed Blobs, and reusing the same URL
-// string keeps src equality checks (background pickers, upload dedupe) working.
+// project switches: they only pin disk-backed Blobs (never heap strings), and
+// unsaved state or undo history may still reference any asset seen this
+// session, so revoking would break those references. Reusing the same URL
+// string also keeps src equality checks (background pickers, upload dedupe)
+// working. Data URLs are intentionally not memoized to their asset id — a
+// cache would pin the full base64 string in the heap; re-hashing on the rare
+// save that still carries one is cheaper than that.
 const objectUrlByAssetId = new Map<string, string>()
 const assetIdByObjectUrl = new Map<string, string>()
-const assetIdByDataUrl = new Map<string, string>()
 
 const toObjectUrl = (id: string, blob: Blob): string => {
   const cached = objectUrlByAssetId.get(id)
@@ -85,9 +89,7 @@ export const importBlobAsset = async (blob: Blob): Promise<string> => {
 /** Same fallback contract as {@link importBlobAsset}, for data URL inputs. */
 export const importDataUrlAsset = async (dataUrl: string): Promise<string> => {
   try {
-    const { id, url } = await storeBlobAsset(dataUrlToBlob(dataUrl))
-    assetIdByDataUrl.set(dataUrl, id)
-    return url
+    return (await storeBlobAsset(dataUrlToBlob(dataUrl))).url
   } catch {
     return dataUrl
   }
@@ -149,13 +151,12 @@ export const hydrateProjectAssets = async <T extends ProjectAssetSources>(projec
 export const dehydrateProjectAssets = async <T extends ProjectAssetSources>(project: T): Promise<T> => {
   const replacements = new Map<string, string>()
   for (const src of collectAssetSources(project)) {
-    const registeredId = assetIdByObjectUrl.get(src) ?? assetIdByDataUrl.get(src)
+    const registeredId = assetIdByObjectUrl.get(src)
     if (registeredId) {
       replacements.set(src, `${ASSET_REF_PREFIX}${registeredId}`)
     } else if (src.startsWith('data:')) {
       try {
         const { id } = await storeBlobAsset(dataUrlToBlob(src))
-        assetIdByDataUrl.set(src, id)
         replacements.set(src, `${ASSET_REF_PREFIX}${id}`)
       } catch {
         // Keep the data URL inline; the project still round-trips.

--- a/src/components/AiGenerateModal.tsx
+++ b/src/components/AiGenerateModal.tsx
@@ -389,6 +389,7 @@ export const AiGenerateModal = ({ open, onClose, controller, targetSlide, onPrep
   const fileInputRef = useRef<HTMLInputElement>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
   const cancelledRef = useRef(false)
+  const runActiveRef = useRef(false)
 
   const requestClose = () => {
     if (phase === 'running' || keysDialogOpen || codexDialogOpen) return
@@ -491,17 +492,19 @@ export const AiGenerateModal = ({ open, onClose, controller, targetSlide, onPrep
   }
 
   const handleGenerate = async () => {
-    if (!canGenerate || phase === 'running') return
+    // The run is marked active before the asynchronous preparation await, so a
+    // second click cannot start a parallel run and the close/cancel guards
+    // already apply while attachments are still being stored.
+    if (!canGenerate || phase === 'running' || runActiveRef.current) return
+    runActiveRef.current = true
     const filesToPrepare = [
       ...screenshots.map((shot) => ({ name: shot.name, dataUrl: shot.dataUrl })),
       ...(!isEditMode && logo ? [{ name: logo.name, dataUrl: logo.dataUrl }] : []),
     ]
-    const prepared = await onPrepareRun(filesToPrepare)
-    const preparedScreenshots = prepared.slice(0, screenshots.length)
-    const preparedLogo = !isEditMode && logo ? prepared[screenshots.length] : undefined
     const abortController = new AbortController()
     abortControllerRef.current = abortController
     cancelledRef.current = false
+    const wasCancelled = () => cancelledRef.current
     setAssistantText('')
     setNarration(createNarrationState())
     setPlan([])
@@ -510,19 +513,34 @@ export const AiGenerateModal = ({ open, onClose, controller, targetSlide, onPrep
     setErrorMessage(null)
     setDoneInfo(null)
     setPhase('running')
-    await runAiGeneration({
-      selection,
-      description,
-      screenshots: preparedScreenshots,
-      ...(!isEditMode && appName.trim() ? { appName: appName.trim() } : {}),
-      ...(preparedLogo ? { logo: preparedLogo } : {}),
-      controller,
-      ...(targetSlide ? { targetSlideId: targetSlide.id } : {}),
-      ...(htmlMode ? { htmlMode: true } : {}),
-      signal: abortController.signal,
-      onEvent: handleEvent,
-      ...(onActivity ? { onActivity } : {}),
-    })
+    try {
+      const prepared = await onPrepareRun(filesToPrepare)
+      if (wasCancelled()) return
+      const preparedScreenshots = prepared.slice(0, screenshots.length)
+      const preparedLogo = !isEditMode && logo ? prepared[screenshots.length] : undefined
+      await runAiGeneration({
+        selection,
+        description,
+        screenshots: preparedScreenshots,
+        ...(!isEditMode && appName.trim() ? { appName: appName.trim() } : {}),
+        ...(preparedLogo ? { logo: preparedLogo } : {}),
+        controller,
+        ...(targetSlide ? { targetSlideId: targetSlide.id } : {}),
+        ...(htmlMode ? { htmlMode: true } : {}),
+        signal: abortController.signal,
+        onEvent: handleEvent,
+        ...(onActivity ? { onActivity } : {}),
+      })
+    } catch (error) {
+      if (!wasCancelled()) {
+        setNarration(flushNarration)
+        setErrorMessage(error instanceof Error ? error.message : String(error))
+        setPhase('error')
+        onActivity?.(null)
+      }
+    } finally {
+      runActiveRef.current = false
+    }
   }
 
   const handleCancel = () => {

--- a/src/components/AiGenerateModal.tsx
+++ b/src/components/AiGenerateModal.tsx
@@ -60,7 +60,7 @@ export type AiGenerateModalProps = {
   controller: AiEditorController
   /** `html` set means the target is an AI-authored HTML screen; edits then run the HTML toolset. */
   targetSlide?: { id: string; name: string; html?: string }
-  onPrepareRun: (files: { name: string; dataUrl: string }[]) => { assetId: string; name: string; dataUrl: string }[]
+  onPrepareRun: (files: { name: string; dataUrl: string }[]) => Promise<{ assetId: string; name: string; dataUrl: string }[]>
   onFinished: (slidesCreated: number) => void
   onActivity?: (activity: AiToolActivity | null) => void
 }
@@ -496,7 +496,7 @@ export const AiGenerateModal = ({ open, onClose, controller, targetSlide, onPrep
       ...screenshots.map((shot) => ({ name: shot.name, dataUrl: shot.dataUrl })),
       ...(!isEditMode && logo ? [{ name: logo.name, dataUrl: logo.dataUrl }] : []),
     ]
-    const prepared = onPrepareRun(filesToPrepare)
+    const prepared = await onPrepareRun(filesToPrepare)
     const preparedScreenshots = prepared.slice(0, screenshots.length)
     const preparedLogo = !isEditMode && logo ? prepared[screenshots.length] : undefined
     const abortController = new AbortController()

--- a/src/editor/use-editor-actions.ts
+++ b/src/editor/use-editor-actions.ts
@@ -1,7 +1,8 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react'
+import { importBlobAsset } from '../asset-store'
 import { makeTemplate } from '../data'
 import { getDevicePlacement } from '../mockups/catalog'
-import { fileToDataUrl, uid } from '../utils'
+import { uid } from '../utils'
 import { freshElementIds } from './element-utils'
 import { panelRevealForAddedSlide, removeSlide } from './slide-operations'
 import type {
@@ -271,7 +272,7 @@ export function useEditorActions({
     const assets = await Promise.all(accepted.map(async (file) => ({
       id: uid('upload'),
       name: file.name,
-      src: await fileToDataUrl(file),
+      src: await importBlobAsset(file),
     })))
     setUploads((current) => [...assets, ...current])
     if (assets.length > 0) {
@@ -280,14 +281,14 @@ export function useEditorActions({
   }, [setToast, setUploads])
 
   const uploadToSelectedDevice = useCallback(async (file: File) => {
-    const asset = { id: uid('upload'), name: file.name, src: await fileToDataUrl(file) }
+    const asset = { id: uid('upload'), name: file.name, src: await importBlobAsset(file) }
     setUploads((current) => [asset, ...current])
     setDeviceImage(asset)
   }, [setDeviceImage, setUploads])
 
   const uploadBackgroundImage = useCallback(async (file: File) => {
     if (rejectHtmlSlideEdit()) return
-    const asset = { id: uid('upload'), name: file.name, src: await fileToDataUrl(file) }
+    const asset = { id: uid('upload'), name: file.name, src: await importBlobAsset(file) }
     setUploads((current) => [asset, ...current])
     commit((current) => current.map((slide) => slide.id === activeSlideId
       ? {

--- a/src/persistence-db.ts
+++ b/src/persistence-db.ts
@@ -1,0 +1,52 @@
+// Keep the established IndexedDB name so rebranding never strands local projects.
+const DATABASE_NAME = 'frameflow'
+const DATABASE_VERSION = 3
+
+export const PROJECT_STORE = 'projects'
+export const SETTINGS_STORE = 'settings'
+export const ASSET_STORE = 'assets'
+
+let databasePromise: Promise<IDBDatabase> | null = null
+
+export const openDatabase = (): Promise<IDBDatabase> => {
+  if (databasePromise) return databasePromise
+
+  databasePromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION)
+    let settled = false
+
+    const fail = (error: Error) => {
+      settled = true
+      databasePromise = null
+      reject(error)
+    }
+
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(PROJECT_STORE)) {
+        request.result.createObjectStore(PROJECT_STORE, { keyPath: 'id' })
+      }
+      if (!request.result.objectStoreNames.contains(SETTINGS_STORE)) {
+        request.result.createObjectStore(SETTINGS_STORE, { keyPath: 'key' })
+      }
+      if (!request.result.objectStoreNames.contains(ASSET_STORE)) {
+        request.result.createObjectStore(ASSET_STORE, { keyPath: 'id' })
+      }
+    }
+    request.onsuccess = () => {
+      if (settled) {
+        request.result.close()
+        return
+      }
+      settled = true
+      request.result.onversionchange = () => {
+        request.result.close()
+        databasePromise = null
+      }
+      resolve(request.result)
+    }
+    request.onerror = () => fail(request.error ?? new Error('Local project storage could not be opened.'))
+    request.onblocked = () => fail(new Error('Local project storage is blocked by another tab.'))
+  })
+
+  return databasePromise
+}

--- a/src/persistence-db.ts
+++ b/src/persistence-db.ts
@@ -16,6 +16,9 @@ export const openDatabase = (): Promise<IDBDatabase> => {
     let settled = false
 
     const fail = (error: Error) => {
+      // A late error from an already-settled request must not clear a newer
+      // cached promise created by a retry.
+      if (settled) return
       settled = true
       databasePromise = null
       reject(error)

--- a/src/persistence.ts
+++ b/src/persistence.ts
@@ -1,10 +1,12 @@
+import {
+  collectPersistedAssetIds,
+  dehydrateProjectAssets,
+  hydrateProjectAssets,
+  sweepUnusedAssets,
+} from './asset-store'
+import { openDatabase, PROJECT_STORE, SETTINGS_STORE } from './persistence-db'
 import type { Slide, UploadAsset } from './types'
 
-// Keep the established IndexedDB name so rebranding never strands local projects.
-const DATABASE_NAME = 'frameflow'
-const DATABASE_VERSION = 2
-const PROJECT_STORE = 'projects'
-const SETTINGS_STORE = 'settings'
 const ACTIVE_PROJECT_KEY = 'activeProjectId'
 const LEGACY_STORAGE_KEY = 'frameflow-project-v5'
 
@@ -20,48 +22,6 @@ export type PersistedProject = {
 export type ProjectSummary = Pick<PersistedProject, 'id' | 'projectName' | 'createdAt' | 'savedAt'>
 
 type SettingRecord = { key: string; value: string }
-
-let databasePromise: Promise<IDBDatabase> | null = null
-
-const openDatabase = (): Promise<IDBDatabase> => {
-  if (databasePromise) return databasePromise
-
-  databasePromise = new Promise((resolve, reject) => {
-    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION)
-    let settled = false
-
-    const fail = (error: Error) => {
-      settled = true
-      databasePromise = null
-      reject(error)
-    }
-
-    request.onupgradeneeded = () => {
-      if (!request.result.objectStoreNames.contains(PROJECT_STORE)) {
-        request.result.createObjectStore(PROJECT_STORE, { keyPath: 'id' })
-      }
-      if (!request.result.objectStoreNames.contains(SETTINGS_STORE)) {
-        request.result.createObjectStore(SETTINGS_STORE, { keyPath: 'key' })
-      }
-    }
-    request.onsuccess = () => {
-      if (settled) {
-        request.result.close()
-        return
-      }
-      settled = true
-      request.result.onversionchange = () => {
-        request.result.close()
-        databasePromise = null
-      }
-      resolve(request.result)
-    }
-    request.onerror = () => fail(request.error ?? new Error('Local project storage could not be opened.'))
-    request.onblocked = () => fail(new Error('Local project storage is blocked by another tab.'))
-  })
-
-  return databasePromise
-}
 
 export const normalizePersistedProject = (value: unknown): PersistedProject | null => {
   if (!value || typeof value !== 'object') return null
@@ -91,48 +51,74 @@ const summarizeProject = (project: PersistedProject): ProjectSummary => ({
   savedAt: project.savedAt,
 })
 
-const sortProjects = (projects: PersistedProject[]) => [...projects].sort((a, b) => b.savedAt - a.savedAt)
+const sortSummaries = (projects: ProjectSummary[]) => [...projects].sort((a, b) => b.savedAt - a.savedAt)
 
-export const loadProjectWorkspace = async (): Promise<{ activeProject: PersistedProject | null; projects: ProjectSummary[] }> => {
-  const database = await openDatabase()
-
-  return new Promise((resolve, reject) => {
-    const transaction = database.transaction([PROJECT_STORE, SETTINGS_STORE], 'readonly')
-    const projectsRequest = transaction.objectStore(PROJECT_STORE).getAll()
-    const activeRequest = transaction.objectStore(SETTINGS_STORE).get(ACTIVE_PROJECT_KEY)
-
-    transaction.oncomplete = () => {
-      const projects = sortProjects(
-        (projectsRequest.result as unknown[])
-          .map(normalizePersistedProject)
-          .filter((project): project is PersistedProject => project !== null),
-      )
-      const configuredId = (activeRequest.result as SettingRecord | undefined)?.value
-      const activeProject = projects.find((project) => project.id === configuredId) ?? projects[0] ?? null
-      resolve({ activeProject, projects: projects.map(summarizeProject) })
-    }
-    transaction.onerror = () => reject(transaction.error ?? new Error('Local projects could not be loaded.'))
-    transaction.onabort = () => reject(transaction.error ?? new Error('Loading local projects was cancelled.'))
-  })
-}
-
-export const loadProject = async (projectId: string): Promise<PersistedProject | null> => {
-  const database = await openDatabase()
-
-  return new Promise((resolve, reject) => {
+const readProjectRecord = (database: IDBDatabase, projectId: string): Promise<PersistedProject | null> =>
+  new Promise((resolve, reject) => {
     const transaction = database.transaction(PROJECT_STORE, 'readonly')
     const request = transaction.objectStore(PROJECT_STORE).get(projectId)
     request.onsuccess = () => resolve(normalizePersistedProject(request.result))
     request.onerror = () => reject(request.error ?? new Error('The local project could not be loaded.'))
   })
+
+type WorkspaceRecords = { summaries: ProjectSummary[]; activeProject: PersistedProject | null }
+
+// A cursor walk keeps only one project document deserialized at a time, so
+// startup memory peaks at the largest single project instead of the sum of
+// every project — the full document is retained only for the active one.
+const readWorkspaceRecords = (database: IDBDatabase): Promise<WorkspaceRecords> =>
+  new Promise((resolve, reject) => {
+    const transaction = database.transaction([PROJECT_STORE, SETTINGS_STORE], 'readonly')
+    const summaries: ProjectSummary[] = []
+    let activeProject: PersistedProject | null = null
+
+    const activeRequest = transaction.objectStore(SETTINGS_STORE).get(ACTIVE_PROJECT_KEY)
+    activeRequest.onsuccess = () => {
+      const configuredId = (activeRequest.result as SettingRecord | undefined)?.value
+      const cursorRequest = transaction.objectStore(PROJECT_STORE).openCursor()
+      cursorRequest.onsuccess = () => {
+        const cursor = cursorRequest.result
+        if (!cursor) return
+        const project = normalizePersistedProject(cursor.value)
+        if (project) {
+          summaries.push(summarizeProject(project))
+          if (project.id === configuredId) activeProject = project
+        }
+        cursor.continue()
+      }
+    }
+
+    transaction.oncomplete = () => resolve({ summaries: sortSummaries(summaries), activeProject })
+    transaction.onerror = () => reject(transaction.error ?? new Error('Local projects could not be loaded.'))
+    transaction.onabort = () => reject(transaction.error ?? new Error('Loading local projects was cancelled.'))
+  })
+
+export const loadProjectWorkspace = async (): Promise<{ activeProject: PersistedProject | null; projects: ProjectSummary[] }> => {
+  const database = await openDatabase()
+  const { summaries, activeProject } = await readWorkspaceRecords(database)
+  const fallbackId = summaries[0]?.id
+  const record = activeProject ?? (fallbackId ? await readProjectRecord(database, fallbackId) : null)
+  return {
+    activeProject: record ? await hydrateProjectAssets(record) : null,
+    projects: summaries,
+  }
+}
+
+export const loadProject = async (projectId: string): Promise<PersistedProject | null> => {
+  const database = await openDatabase()
+  const record = await readProjectRecord(database, projectId)
+  return record ? hydrateProjectAssets(record) : null
 }
 
 export const saveProject = async (project: PersistedProject): Promise<void> => {
+  // Image blobs are written before the document that references them, so a
+  // failed save can leave an unreferenced blob but never a dangling reference.
+  const record = await dehydrateProjectAssets(project)
   const database = await openDatabase()
 
   return new Promise((resolve, reject) => {
     const transaction = database.transaction(PROJECT_STORE, 'readwrite')
-    transaction.objectStore(PROJECT_STORE).put(project)
+    transaction.objectStore(PROJECT_STORE).put(record)
     transaction.oncomplete = () => resolve()
     transaction.onerror = () => reject(transaction.error ?? new Error('The local project could not be saved.'))
     transaction.onabort = () => reject(transaction.error ?? new Error('Saving the local project was cancelled.'))
@@ -151,16 +137,44 @@ export const setActiveProjectId = async (projectId: string): Promise<void> => {
   })
 }
 
+const collectRemainingAssetIds = (database: IDBDatabase): Promise<Set<string>> =>
+  new Promise((resolve, reject) => {
+    const transaction = database.transaction(PROJECT_STORE, 'readonly')
+    const keep = new Set<string>()
+    const cursorRequest = transaction.objectStore(PROJECT_STORE).openCursor()
+    cursorRequest.onsuccess = () => {
+      const cursor = cursorRequest.result
+      if (!cursor) return
+      const project = normalizePersistedProject(cursor.value)
+      if (project) {
+        for (const id of collectPersistedAssetIds(project)) keep.add(id)
+      }
+      cursor.continue()
+    }
+    transaction.oncomplete = () => resolve(keep)
+    transaction.onerror = () => reject(transaction.error ?? new Error('Local projects could not be scanned.'))
+    transaction.onabort = () => reject(transaction.error ?? new Error('Scanning local projects was cancelled.'))
+  })
+
 export const deleteProject = async (projectId: string): Promise<void> => {
   const database = await openDatabase()
 
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const transaction = database.transaction(PROJECT_STORE, 'readwrite')
     transaction.objectStore(PROJECT_STORE).delete(projectId)
     transaction.oncomplete = () => resolve()
     transaction.onerror = () => reject(transaction.error ?? new Error('The local project could not be deleted.'))
     transaction.onabort = () => reject(transaction.error ?? new Error('Deleting the project was cancelled.'))
   })
+
+  // Best effort: reclaim image blobs no surviving project references. The
+  // project deletion above already succeeded, so a failed sweep only leaves
+  // unused blobs on disk for the next sweep to pick up.
+  try {
+    await sweepUnusedAssets(await collectRemainingAssetIds(database))
+  } catch {
+    // Ignored — see above.
+  }
 }
 
 export const loadLegacyProject = (): { slides: Slide[]; uploads: UploadAsset[] } | null => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,6 +130,11 @@ export type Slide = {
 export type UploadAsset = {
   id: string
   name: string
+  /**
+   * Renderable source. At runtime this is an object URL for a Blob in the
+   * IndexedDB asset store (data URL only when Blob storage is unavailable);
+   * persisted documents carry `blob-asset:` references instead.
+   */
   src: string
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export const downloadBlob = (blob: Blob, filename: string) => {
   URL.revokeObjectURL(url)
 }
 
-export const fileToDataUrl = (file: File) =>
+export const fileToDataUrl = (file: Blob) =>
   new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
     reader.onload = () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
         'src/ai/richtext.ts',
         'src/ai/run-log.ts',
         'src/app/export-image-sizing.ts',
+        'src/asset-sources.ts',
         'src/app/project-utils.ts',
         'src/editor/drag-bounds.ts',
         'src/editor/element-utils.ts',


### PR DESCRIPTION
## Problem

With many projects, the tab's memory footprint grew past 2–3 GB. Two causes:

1. Every image lived as an inline base64 data URL inside project documents, uploads, elements, and device screenshots — sitting in the JS heap alongside the decoded bitmaps.
2. `loadProjectWorkspace()` used `getAll()` at startup, deserializing **every** project (including all image payloads) just to build the project list.

## Changes

- **Content-addressed Blob asset store** (`src/asset-store.ts`, new `assets` object store, DB v3): image bytes are stored as Blobs (disk-backed in Chrome), documents persist `blob-asset:<sha-256>` references, the app renders object URLs. Identical images deduplicate across projects and on duplicate-project.
- **Transparent migration**: legacy documents with inline data URLs convert to stored Blobs on load and persist references on the next save. Never-opened projects stay untouched.
- **Cursor-based workspace load** (`src/persistence.ts`): the project list is built one document at a time; only the active project is fully retained. Startup memory now peaks at the largest single project instead of the sum of all projects.
- **Uploads** store the file Blob directly (data URL fallback when Blob storage is unavailable, e.g. private browsing).
- **AI paths**: attachments register blob assets while provider payloads keep their data URLs; overlay reference images are fetched back to base64 on demand.
- **Asset GC**: deleting a project sweeps Blobs no surviving project references (conservatively keeping session-known assets).
- Pure source-walk logic lives in `src/asset-sources.ts` and is covered by unit tests; persistence roundtrip/migration/sweep are tested against `fake-indexeddb` (new dev dependency).

## Measured effect

In-browser test with a legacy project (445 KB inline base64): document shrank to **670 bytes**, image stored once as a 334 KB Blob shared by upload + device screenshot.

## Verification

- `bun run check` green (structure, typed lint, coverage, strict TS, build, audit); 11 tests passing.
- Manual browser pass: v2→v3 upgrade on an existing DB, legacy project migration renders correctly, Cmd+S persists references, reload hydrates from the asset store, PNG export rasterizes `blob:` sources, project delete + sweep — no console errors. HTML screens are compatible (rendered in a plain `<div>`, no sandboxed iframe).

## Known limit

AI-generated overlay assets keep their data URL in memory until the next reload (`addAsset` controller path is synchronous); they are persisted as Blob references immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more efficient image storage with deduplication and automatic reuse across projects.
  * Improved project loading by loading only the active project’s full content while retaining workspace summaries.
  * Added automatic migration of existing inline images to the new storage format.
  * Added cleanup of unused image assets when projects are deleted.
  * Improved image uploads, screenshots, backgrounds, and generated content handling.

* **Bug Fixes**
  * Improved image reference handling for generated content and object URLs.
  * Prevented overlapping generation runs and improved cancellation and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->